### PR TITLE
Add Rack::ShowExceptions middleware to help debug errors

### DIFF
--- a/lib/blade/server.rb
+++ b/lib/blade/server.rb
@@ -24,6 +24,7 @@ module Blade::Server
   private
     def app
       Rack::Builder.app do
+        use Rack::ShowExceptions
         run Blade::RackAdapter.new
       end
     end


### PR DESCRIPTION
If you try to require a file that doesn't exist, when you render the index page you get `Internal server error` with doesn't provide any hints as to what has gone wrong.

This adds the ShowExceptions rack middleware, to provide error messages that can be debug the errors.