### PR TITLE
Depend on a newer curses version to prevent installation errors on MacOS Big Sur

### DIFF
--- a/blade.gemspec
+++ b/blade.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 
   spec.add_dependency "blade-qunit_adapter", "~> 2.0.1"
   spec.add_dependency "activesupport", ">= 3.0.0"
   spec.add_dependency "coffee-script"
   spec.add_dependency "coffee-script-source"
-  spec.add_dependency "curses", "~> 1.0.0"
+  spec.add_dependency "curses", "~> 1.4.0"
   spec.add_dependency "eventmachine"
   spec.add_dependency "faye"
   spec.add_dependency "sprockets", ">= 3.0"

--- a/blade.gemspec
+++ b/blade.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 3.0.0"
   spec.add_dependency "coffee-script"
   spec.add_dependency "coffee-script-source"
-  spec.add_dependency "curses", "~> 1.4.0"
+  spec.add_dependency "curses", ">= 1.4.0"
   spec.add_dependency "eventmachine"
   spec.add_dependency "faye"
   spec.add_dependency "sprockets", ">= 3.0"


### PR DESCRIPTION
A fresh checkout of Rails on Big Sur leads to this error when running `bundle install`:

`curses.c:1325:5: error: implicit declaration of function 'rb_safe_level' is invalid in C99 [-Werror,-Wimplicit-function-declaration]`

This PR bumps the `curses` dependency to its latest minor version to fix the problem.

[See this rbtrace PR](https://github.com/tmm1/rbtrace/pull/82) for an explanation of the error.