### PR TITLE
Fix Ruby 3.2 compatibility

### DIFF
--- a/lib/blade.rb
+++ b/lib/blade.rb
@@ -126,7 +126,7 @@ module Blade
     end
 
     def blade_file_options
-      if filename = CONFIG_FILENAMES.detect { |name| File.exists?(name) }
+      if filename = CONFIG_FILENAMES.detect { |name| File.exist?(name) }
         YAML.load_file(filename)
       else
         {}


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/44152

`File.exists?` was finally removed after being deprecated for almost a decade.